### PR TITLE
Handles the none case

### DIFF
--- a/src/sklearn_evaluation/plot/grid_search.py
+++ b/src/sklearn_evaluation/plot/grid_search.py
@@ -189,9 +189,10 @@ def _grid_search_double(grid_scores, change, subset, cmap, ax):
     # and sort the results to make sure the matrix axis
     # is showed in increasing order
     row_names = sorted(set([t[0] for t in matrix_elements.keys()]),
-                       key=itemgetter(1))
+                   key=lambda x: (x[1] is None, x[1]))
     col_names = sorted(set([t[1] for t in matrix_elements.keys()]),
-                       key=itemgetter(1))
+                   key=lambda x: (x[1] is None, x[1]))
+
 
     # size of the matrix
     cols = len(col_names)


### PR DESCRIPTION
When `None` is passed as the max_depth for RandomForests, the code returns an error. This commit handles the case by moving `None` to the end of the list while sorting. 
closes #39 